### PR TITLE
Support Laravel 5.6+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "despark/image-purify": "^0.1",
-        "illuminate/support": "5.5.*|5.4.*|5.3.*|5.2.*|5.1.*"
+        "illuminate/support": "^5.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Further updates in the 5.x range is unlike to break the api.